### PR TITLE
Attempt to fix problems with arrow IPC 

### DIFF
--- a/splink_graph/vectorised.py
+++ b/splink_graph/vectorised.py
@@ -1,3 +1,4 @@
+import pyspark
 from pyspark.sql.types import (
     LongType,
     StringType,

--- a/splink_graph/vectorised.py
+++ b/splink_graph/vectorised.py
@@ -26,7 +26,7 @@ import numpy as np
 # setup to work around with pandas udf
 # see answers on
 # https://stackoverflow.com/questions/58458415/pandas-scalar-udf-failing-illegalargumentexception
-os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
+
 
 eboutSchema = StructType(
     [
@@ -44,7 +44,10 @@ def edgebetweeness(sparkdf, src="src", dst="dst", distance="distance",component=
 
     conf = SparkConf()
     conf.set("spark.sql.execution.arrow.enabled", "true")
-    conf.set("spark.executorEnv.ARROW_PRE_0_15_IPC_FORMAT", "1")
+    if (pyspark.__version__).startswith("2"):
+        conf.set("spark.executorEnv.ARROW_PRE_0_15_IPC_FORMAT", "1")
+        os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
+    
     sc = SparkContext.getOrCreate(conf=conf)
 
     psrc = src


### PR DESCRIPTION
This prevents errors on Spark 3.  I haven't checked whether it works in Spark 2.  

Basically Spark 3 doesn't need any special options set.  It prefers there to be no `ARROW_PRE_0_15_IPC_FORMAT` in the env.

If tests pass does this mean we're ok?

Closes #21  if this works